### PR TITLE
chore(docker): update builder-image to golang version 1.24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.22-alpine AS build
+FROM golang:1.24-alpine AS build
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY


### PR DESCRIPTION
This PR updates the builder image used in the multistage docker build.