### PR TITLE
chore(ci): update golangci-lint workflow to run on every branch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,8 +6,6 @@ name: Linting
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
This PR updates the golangci-lint workflow to run on every branch when pushing.