### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Run go test
         run: go test -v ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./... -tags=testing -p=1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,11 +16,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.6.1

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v4
+        uses: fsfe/reuse-action@3ae3c6bdf1257ab19397fab11fd3312144692083 # v4

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Quasar is a tiny service for synchronizing the state of custom resources with ca
 
 [![REUSE status](https://api.reuse.software/badge/github.com/telekom/pubsub-horizon-quasar)](https://api.reuse.software/info/github.com/telekom/pubsub-horizon-quasar)
 [![Go Test](https://github.com/telekom/pubsub-horizon-quasar/actions/workflows/go-test.yml/badge.svg)](https://github.com/telekom/pubsub-horizon-quasar/actions/workflows/go-test.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/telekom/pubsub-horizon-quasar)
 
 ## Overview
 Quasar is the config-controller powering the Horizon ecosystem. 


### PR DESCRIPTION
## Summary
- Add DeepWiki badge to README for AI-powered documentation exploration
- Pin all GitHub Actions to full-length commit SHAs (org policy compliance)
- Replace `go-version: stable` / `go-version: 1.22` with `go-version-file: go.mod` across all workflows